### PR TITLE
Changed buildDelay sleep from Millisecond to Nanosecond

### DIFF
--- a/runner/start.go
+++ b/runner/start.go
@@ -61,7 +61,7 @@ func start() {
 			if isDebug() {
 				mainLog("Sleeping for %d milliseconds...", buildDelay)
 			}
-			time.Sleep(buildDelay * time.Millisecond)
+			time.Sleep(buildDelay * time.Nanosecond)
 			if isDebug() {
 				mainLog("Flushing events")
 			}


### PR DESCRIPTION
Changed the sleep time with buildDelay to Nanosecod as per [README.md default settings](git@github.com:NaveenPantra/fresh.git)